### PR TITLE
Refactor DataTab to use scrollable DataTable for data preview

### DIFF
--- a/src/datanomy/tui/parquet.py
+++ b/src/datanomy/tui/parquet.py
@@ -798,15 +798,10 @@ class DataTab(BaseParquetTab):
             DataTable: Configured widget ready for display
         """
 
-        data_table: DataTable = DataTable(id="data-preview-table")
-        data_table.show_row_labels = False
-        data_table.show_cursor = True
-        data_table.cursor_type = "cell"
-        data_table.zebra_stripes = True
+        data_table: DataTable = DataTable(id="data-preview-table", zebra_stripes=True)
         data_table.border_title = "Data Preview"
         data_table.styles.border = ("round", "cyan")
         data_table.styles.width = "auto"
-        data_table.styles.margin = (1, 0, 0, 0)
 
         columns = list(table.schema.names)
         if not columns:


### PR DESCRIPTION
**Summary**
Replace the Rich `Table` preview with Textual’s `DataTable`, wrapping it in `HorizontalScroll` so wide Parquet schemas stay accessible while preserving formatting. This is just one possible implementation.

**Changes**
- Swap `_create_data_table` to build a Textual `DataTable` (cursor support, zebra stripes, border styling, NULL highlighting).
- Size columns via header-based `min_width` and wrap the widget in `HorizontalScroll` inside `compose` so wide schemas remain accessible.
- Yield `Static` error/empty states through the Textual compose API to match the new widget structure.

Closes #23