### PR TITLE
Initial arrow data IPC file visualization panels and design

### DIFF
--- a/src/datanomy/cli.py
+++ b/src/datanomy/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import click
 
-from datanomy.reader.parquet import ParquetReader
+from datanomy.reader import create_reader
 from datanomy.tui.tui import DatanomyApp
 
 
@@ -13,14 +13,14 @@ from datanomy.tui.tui import DatanomyApp
 @click.argument("file", type=click.Path(exists=True, path_type=Path))
 def main(file: Path) -> None:
     """
-    Explore the anatomy of your Parquet files.
+    Explore the anatomy of your data files.
 
     Parameters
     ----------
-        file: Path to a Parquet file to inspect
+        file: Path to a Parquet or Arrow IPC file to inspect
     """
     try:
-        reader = ParquetReader(file)
+        reader = create_reader(file)
         app = DatanomyApp(reader)
         app.run()
     except Exception as e:

--- a/src/datanomy/reader/__init__.py
+++ b/src/datanomy/reader/__init__.py
@@ -1,0 +1,61 @@
+"""Reader factory with format auto-detection."""
+
+from pathlib import Path
+
+from datanomy.reader.ipc import IPCReader
+from datanomy.reader.parquet import ParquetReader
+
+PARQUET_EXTENSIONS = {".parquet", ".parq"}
+IPC_EXTENSIONS = {".arrow", ".feather", ".ipc"}
+
+PARQUET_MAGIC = b"PAR1"
+IPC_MAGIC = b"ARROW1"
+
+
+def create_reader(file_path: Path) -> ParquetReader | IPCReader:
+    """
+    Create the appropriate reader based on file format.
+
+    Detection strategy:
+        1. File extension if recognized
+        2. Magic bytes fallback for unknown extensions
+
+    Parameters
+    ----------
+        file_path: Path to the file to inspect
+
+    Returns
+    -------
+        ParquetReader or IPCReader
+
+    Raises
+    ------
+        FileNotFoundError: If the file does not exist
+        ValueError: If the file format cannot be determined
+    """
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    suffix = file_path.suffix.lower()
+
+    if suffix in PARQUET_EXTENSIONS:
+        return ParquetReader(file_path)
+
+    if suffix in IPC_EXTENSIONS:
+        return IPCReader(file_path)
+
+    # Unknown extension — try magic bytes
+    with open(file_path, "rb") as f:
+        header = f.read(6)
+
+    if header[:4] == PARQUET_MAGIC:
+        return ParquetReader(file_path)
+
+    if header == IPC_MAGIC:
+        return IPCReader(file_path)
+
+    raise ValueError(
+        f"Cannot determine file format for {file_path}. "
+        f"Supported formats: Parquet ({', '.join(PARQUET_EXTENSIONS)}), "
+        f"Arrow IPC ({', '.join(IPC_EXTENSIONS)})"
+    )

--- a/src/datanomy/reader/ipc.py
+++ b/src/datanomy/reader/ipc.py
@@ -1,0 +1,110 @@
+"""Arrow IPC file reader."""
+
+from pathlib import Path
+from typing import Any
+
+import functools
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+
+class IPCReader:
+    """Main class to read and inspect Arrow IPC files."""
+
+    def __init__(self, file_path: Path) -> None:
+        """
+        Initialize the RecordBatchFileReader for Arrow file format.
+
+        Parameters
+        ----------
+            file_path: Path to the Arrow IPC file
+
+        Raises
+        ------
+            FileNotFoundError: If the file does not exist
+            ArrowInvalid: If the file is not a valid Arrow IPC file
+            ArrowIOError: If the file cannot be read
+        """
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            self.file_path = file_path
+            self.ipc_file = ipc.open_file(file_path)
+        except pa.ArrowInvalid as e:
+            raise pa.ArrowInvalid(
+                f"{file_path} does not appear to be a valid Arrow IPC file"
+            ) from e
+        except pa.ArrowIOError as e:
+            raise pa.ArrowIOError(f"{file_path} could not be read") from e
+
+    @property
+    def schema_arrow(self) -> Any:
+        """
+        Get the Arrow schema.
+
+        Returns
+        -------
+            Arrow schema for the Arrow IPC file
+        """
+        return self.ipc_file.schema
+
+    @property
+    def metadata(self) -> Any:
+        """
+        Get schema-level metadata.
+
+        Returns
+        -------
+            Dictionary of key-value pairs
+        """
+        return self.ipc_file.schema.metadata
+
+    @property
+    def num_record_batches(self) -> int:
+        """
+        Get total number of batches.
+
+        Returns
+        -------
+            Total number of batches in the Arrow IPC file
+        """
+        return int(self.ipc_file.num_record_batches)
+
+    @functools.cached_property
+    def num_rows(self) -> int:
+        """
+        Get total number of rows.
+
+        Returns
+        -------
+            Total number of rows in the Arrow IPC file
+        """
+        return sum(
+            self.ipc_file.get_batch(i).num_rows for i in range(self.num_record_batches)
+        )
+
+    @property
+    def file_size(self) -> int:
+        """
+        Get file size in bytes.
+
+        Returns
+        -------
+            File size in bytes
+        """
+        return int(self.file_path.stat().st_size)
+
+    def get_batch(self, index: int) -> pa.RecordBatch:
+        """
+        Get a specific record batch.
+
+        Parameters
+        ----------
+            index: Record batch index
+
+        Returns
+        -------
+            RecordBatch
+        """
+        return self.ipc_file.get_batch(index)

--- a/src/datanomy/tui/ipc.py
+++ b/src/datanomy/tui/ipc.py
@@ -1,0 +1,446 @@
+"""Terminal UI tabs for exploring Arrow IPC files."""
+
+from typing import Any
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import HorizontalScroll, Vertical
+from textual.widgets import DataTable, Static
+
+from datanomy.reader.ipc import IPCReader
+from datanomy.tui.common import create_column_grid
+from datanomy.utils import format_size
+
+
+class BaseIPCTab(Static):
+    """Base class for Arrow IPC-specific tab widgets."""
+
+    def __init__(self, reader: IPCReader) -> None:
+        """
+        Initialize the tab view.
+
+        Parameters
+        ----------
+            reader: IPCReader instance
+        """
+        super().__init__()
+        self.reader = reader
+
+    def compose(self) -> ComposeResult:
+        """Render the tab view."""
+        content_id = f"{self.__class__.__name__.lower().replace('tab', '')}-content"
+        yield Static(self.render_tab_content(), id=content_id)
+
+    def render_tab_content(self) -> Group:
+        """
+        Render the tab content. Must be implemented by subclasses.
+
+        Returns
+        -------
+            Group: Rich renderable content
+        """
+        raise NotImplementedError("Subclasses must implement render_tab_content()")
+
+
+class StructureTab(BaseIPCTab):
+    """Widget displaying Arrow IPC file structure."""
+
+    def _header(self) -> Panel:
+        """
+        Create Text for Arrow IPC Header information.
+
+        Returns
+        -------
+            Panel: Rich Panel with Arrow IPC Header representation
+        """
+        header_text = Text()
+        header_text.append("Magic Number: ARROW1\n", style="yellow")
+        header_text.append("Size: 6 bytes")
+        return Panel(
+            header_text,
+            title="Header",
+            border_style="yellow",
+        )
+
+    def _file_info(self) -> Text:
+        """
+        Create Text for Arrow IPC File information.
+
+        Returns
+        -------
+            Text: Rich Text with File Information representation
+        """
+        file_size_str = format_size(self.reader.file_size)
+
+        file_info = Text()
+        file_info.append("File: ", style="bold")
+        file_info.append(f"{self.reader.file_path.name}\n")
+        file_info.append("Size: ", style="bold")
+        file_info.append(file_size_str)
+        return file_info
+
+    def _record_batches(self) -> list[Panel]:
+        """
+        Create Panels for each Record Batch.
+
+        Returns
+        -------
+            list[Panel]: List of Rich Panels for Record Batches
+        """
+        panels: list[Panel] = []
+        for i in range(self.reader.num_record_batches):
+            batch = self.reader.get_batch(i)
+
+            batch_text = Text()
+            batch_text.append(f"Rows: {batch.num_rows:,}\n")
+            batch_text.append(f"Columns: {batch.num_columns}\n")
+            batch_text.append(f"Size: {format_size(batch.nbytes)}")
+
+            panel = Panel(
+                batch_text,
+                title=f"[green]Record Batch {i}[/green]",
+                border_style="green",
+            )
+            panels.append(panel)
+        return panels
+
+    def _footer(self) -> Panel:
+        """
+        Create Text for Arrow IPC Footer information.
+
+        Returns
+        -------
+            Panel: Rich Panel with Arrow IPC Footer representation
+        """
+        footer_text = Text()
+        footer_text.append(f"Total Rows: {self.reader.num_rows:,}\n")
+        footer_text.append(f"Record Batches: {self.reader.num_record_batches}\n")
+        footer_text.append("Magic Number: ARROW1", style="yellow")
+        footer_text.append(" (6 bytes)")
+        return Panel(footer_text, title="[blue]Footer[/blue]", border_style="blue")
+
+    def render_tab_content(self) -> Group:
+        """
+        Render the Arrow IPC file structure diagram.
+
+        Returns
+        -------
+            Group: Rich renderable showing file structure
+        """
+        sections: list[Text | Panel] = [
+            self._file_info(),
+            Text(),
+            self._header(),
+            Text(),
+        ]
+        sections.extend(self._record_batches())
+        sections.extend([Text(), self._footer()])
+        return Group(*sections)
+
+
+class SchemaTab(BaseIPCTab):
+    """Widget displaying Arrow schema information."""
+
+    def _schema_structure(self) -> Panel:
+        """
+        Create Panel for Arrow schema structure.
+
+        Returns
+        -------
+            Panel: Rich Panel with schema structure
+        """
+        schema = self.reader.schema_arrow
+        schema_text = Text()
+        for field in schema:
+            nullable = "nullable" if field.nullable else "not null"
+            schema_text.append(
+                f"{field.name}: {field.type} ({nullable})\n", style="dim"
+            )
+
+        return Panel(
+            schema_text,
+            title="[yellow]Arrow Schema[/yellow]",
+            border_style="yellow",
+        )
+
+    def _column_details(self) -> Panel:
+        """
+        Create Panel with column details grid.
+
+        Returns
+        -------
+            Panel: Rich Panel containing column information in a 3-column grid
+        """
+        schema = self.reader.schema_arrow
+        num_columns = len(schema)
+
+        schema_table = create_column_grid(num_columns=3)
+
+        cols_per_row = 3
+        for row_idx in range(0, num_columns, cols_per_row):
+            row_panels: list[Panel | Text] = []
+
+            for col_offset in range(cols_per_row):
+                col_idx = row_idx + col_offset
+                if col_idx < num_columns:
+                    field = schema.field(col_idx)
+
+                    col_text = Text()
+                    col_text.append("Type: ", style="bold")
+                    col_text.append(f"{field.type}\n", style="yellow")
+                    col_text.append("Nullable: ", style="bold")
+                    col_text.append(f"{field.nullable}\n", style="dim")
+                    if field.metadata:
+                        col_text.append("Field metadata: ", style="bold")
+                        col_text.append("Yes\n", style="dim")
+
+                    col_panel = Panel(
+                        col_text,
+                        title=f"[green]{field.name}[/green]",
+                        border_style="cyan",
+                        padding=(0, 1),
+                    )
+                    row_panels.append(col_panel)
+                else:
+                    row_panels.append(Text(""))
+
+            schema_table.add_row(*row_panels)
+
+        return Panel(
+            schema_table,
+            title="[cyan]Column Details[/cyan]",
+            border_style="cyan",
+        )
+
+    def render_tab_content(self) -> Group:
+        """
+        Render schema information.
+
+        Returns
+        -------
+            Group: Rich renderable showing Arrow schema as column panels and structure
+        """
+        return Group(self._schema_structure(), Text(), self._column_details())
+
+
+class DataTab(BaseIPCTab):
+    """Widget displaying data preview."""
+
+    def __init__(self, reader: IPCReader, num_rows: int = 50) -> None:
+        """
+        Initialize the data view.
+
+        Parameters
+        ----------
+            reader: IPCReader instance
+            num_rows: Number of rows to display (default: 50)
+        """
+        super().__init__(reader)
+        self.num_rows = num_rows
+        self.id = "data-content"
+
+    @staticmethod
+    def _format_value(value: Any, max_length: int = 50) -> str:
+        """
+        Format a value for display.
+
+        Parameters
+        ----------
+            value: The value to format
+            max_length: Maximum string length before truncation
+
+        Returns
+        -------
+            str: Formatted value string
+        """
+        if value is None:
+            return "NULL"
+
+        value_str = str(value)
+        if len(value_str) > max_length:
+            return f"{value_str[: max_length - 3]}..."
+        return value_str
+
+    def _read_data(self) -> tuple[Any, int, int]:
+        """
+        Read and slice data from Arrow IPC file.
+
+        Returns
+        -------
+            tuple[Any, int, int]: (table, num_rows_display, total_rows)
+
+        Raises
+        ------
+            Exception: If reading data fails
+        """
+        table = self.reader.ipc_file.read_all()
+
+        if len(table) > self.num_rows:
+            table = table.slice(0, self.num_rows)
+
+        num_rows_display = len(table)
+        total_rows = self.reader.num_rows
+
+        return table, num_rows_display, total_rows
+
+    def _create_data_table(self, table: Any, num_rows_display: int) -> DataTable:
+        """
+        Create a Textual ``DataTable`` widget populated with preview rows.
+
+        Parameters
+        ----------
+            table: PyArrow table slice for preview rendering
+            num_rows_display: Number of rows to include in the table
+
+        Returns
+        -------
+            DataTable: Configured widget ready for display
+        """
+        data_table: DataTable = DataTable(id="data-preview-table", zebra_stripes=True)
+        data_table.border_title = "Data Preview"
+        data_table.styles.border = ("round", "cyan")
+        data_table.styles.width = "auto"
+
+        columns = list(table.schema.names)
+        if not columns:
+            return data_table
+
+        min_width = max(80, sum(max(12, len(name) + 2) for name in columns))
+        data_table.styles.min_width = min_width
+
+        data_table.add_columns(*columns)
+
+        for row_idx in range(num_rows_display):
+            row_values: list[str | Text] = []
+            for name in columns:
+                value = table[name][row_idx].as_py()
+                formatted_value = self._format_value(value)
+                if value is None:
+                    row_values.append(Text(formatted_value, style="dim yellow"))
+                else:
+                    row_values.append(formatted_value)
+            data_table.add_row(*row_values)
+
+        return data_table
+
+    def compose(self) -> ComposeResult:
+        """
+        Compose widgets for the data preview tab.
+
+        Yields
+        ------
+            ComposeResult: Child widgets making up the tab content
+        """
+        try:
+            table, num_rows_display, total_rows = self._read_data()
+        except Exception as e:
+            error_text = Text()
+            error_text.append(f"Error reading data: {e}", style="red")
+            yield Static(Panel(error_text, title="[red]Error[/red]"), id="data-content")
+            return
+
+        columns = list(table.schema.names)
+        data_widget: DataTable | None = None
+        empty_panel: Panel | None = None
+
+        if columns:
+            data_widget = self._create_data_table(table, num_rows_display)
+        else:
+            empty_text = Text("Table has no columns", style="yellow")
+            empty_panel = Panel(
+                empty_text,
+                title="[cyan]Data Preview[/cyan]",
+                border_style="cyan",
+            )
+
+        header_text = Text()
+        header_text.append(
+            f"Showing {num_rows_display:,} of {total_rows:,} rows", style="cyan bold"
+        )
+
+        with Vertical(id="data-content"):
+            yield Static(header_text)
+
+            if data_widget is not None:
+                with HorizontalScroll():
+                    yield data_widget
+            elif empty_panel is not None:
+                yield Static(empty_panel)
+
+
+class MetadataTab(BaseIPCTab):
+    """Display Arrow IPC file metadata."""
+
+    def _file_info(self) -> Panel:
+        """
+        Create Panel with file information.
+
+        Returns
+        -------
+            Panel: Rich Panel with file metadata information
+        """
+        file_info = Text()
+
+        file_info.append("File size: ", style="bold")
+        file_info.append(f"{format_size(self.reader.file_size)}\n", style="cyan")
+        file_info.append("Total rows: ", style="bold")
+        file_info.append(f"{self.reader.num_rows:,}\n", style="green")
+        file_info.append("Total columns: ", style="bold")
+        file_info.append(f"{len(self.reader.schema_arrow)}\n", style="green")
+        file_info.append("Record batches: ", style="bold")
+        file_info.append(f"{self.reader.num_record_batches}\n", style="green")
+
+        return Panel(
+            file_info,
+            title="[cyan]File Information[/cyan]",
+            border_style="cyan",
+        )
+
+    def _custom_metadata(self) -> Panel:
+        """
+        Create Panel with custom metadata.
+
+        Returns
+        -------
+            Panel: Rich Panel with custom metadata key-value pairs
+        """
+        metadata = self.reader.metadata
+        custom_metadata = Text()
+
+        if metadata:
+            for key, value in metadata.items():
+                key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+                value_str = value.decode("utf-8") if isinstance(value, bytes) else value
+
+                custom_metadata.append(f"{key_str}:\n", style="bold yellow")
+                if len(value_str) > 200:
+                    custom_metadata.append(
+                        f"  {value_str[:200]}...\n", style="dim white"
+                    )
+                    custom_metadata.append(
+                        f"  (truncated, {len(value_str)} bytes total)\n",
+                        style="italic magenta",
+                    )
+                else:
+                    custom_metadata.append(f"  {value_str}\n", style="white")
+                custom_metadata.append("\n")
+        else:
+            custom_metadata.append("No custom metadata found", style="dim yellow")
+
+        return Panel(
+            custom_metadata,
+            title="[cyan]Custom Metadata[/cyan]",
+            border_style="cyan",
+        )
+
+    def render_tab_content(self) -> Group:
+        """
+        Render file metadata.
+
+        Returns
+        -------
+            Group: Rich renderable showing file and custom metadata
+        """
+        return Group(self._file_info(), Text(), self._custom_metadata())

--- a/src/datanomy/tui/tui.py
+++ b/src/datanomy/tui/tui.py
@@ -1,15 +1,20 @@
-"""Terminal UI for exploring Parquet files."""
+"""Terminal UI for exploring data files."""
 
 from textual.app import App, ComposeResult
 from textual.containers import ScrollableContainer
 from textual.widgets import Footer, Header, TabbedContent, TabPane
 
+from datanomy.reader.ipc import IPCReader
 from datanomy.reader.parquet import ParquetReader
+from datanomy.tui.ipc import DataTab as IPCDataTab
+from datanomy.tui.ipc import MetadataTab as IPCMetadataTab
+from datanomy.tui.ipc import SchemaTab as IPCSchemaTab
+from datanomy.tui.ipc import StructureTab as IPCStructureTab
 from datanomy.tui.parquet import DataTab, MetadataTab, SchemaTab, StatsTab, StructureTab
 
 
 class DatanomyApp(App):
-    """A Textual app to explore Parquet file anatomy."""
+    """A Textual app to explore data file anatomy."""
 
     CSS = """
     TabbedContent {
@@ -27,13 +32,13 @@ class DatanomyApp(App):
 
     BINDINGS = [("q", "quit", "Quit")]
 
-    def __init__(self, reader: ParquetReader) -> None:
+    def __init__(self, reader: ParquetReader | IPCReader) -> None:
         """
         Initialize the app.
 
         Parameters
         ----------
-            reader: ParquetReader instance
+            reader: ParquetReader or IPCReader instance
         """
         super().__init__()
         self.reader = reader
@@ -48,14 +53,46 @@ class DatanomyApp(App):
         """
         yield Header()
         with TabbedContent():
-            with TabPane("Structure", id="tab-structure"):
-                yield ScrollableContainer(StructureTab(self.reader))
-            with TabPane("Schema", id="tab-schema"):
-                yield ScrollableContainer(SchemaTab(self.reader))
-            with TabPane("Data", id="tab-data"):
-                yield ScrollableContainer(DataTab(self.reader))
-            with TabPane("Metadata", id="tab-metadata"):
-                yield ScrollableContainer(MetadataTab(self.reader))
-            with TabPane("Stats", id="tab-stats"):
-                yield ScrollableContainer(StatsTab(self.reader))
+            if isinstance(self.reader, ParquetReader):
+                yield from self._parquet_tabs()
+            else:
+                yield from self._ipc_tabs()
         yield Footer()
+
+    def _parquet_tabs(self) -> ComposeResult:
+        """
+        Create Parquet-specific tabs.
+
+        Yields
+        ------
+            ComposeResult: Parquet tab panes
+        """
+        assert isinstance(self.reader, ParquetReader)
+        with TabPane("Structure", id="tab-structure"):
+            yield ScrollableContainer(StructureTab(self.reader))
+        with TabPane("Schema", id="tab-schema"):
+            yield ScrollableContainer(SchemaTab(self.reader))
+        with TabPane("Data", id="tab-data"):
+            yield ScrollableContainer(DataTab(self.reader))
+        with TabPane("Metadata", id="tab-metadata"):
+            yield ScrollableContainer(MetadataTab(self.reader))
+        with TabPane("Stats", id="tab-stats"):
+            yield ScrollableContainer(StatsTab(self.reader))
+
+    def _ipc_tabs(self) -> ComposeResult:
+        """
+        Create Arrow IPC-specific tabs.
+
+        Yields
+        ------
+            ComposeResult: IPC tab panes
+        """
+        assert isinstance(self.reader, IPCReader)
+        with TabPane("Structure", id="tab-structure"):
+            yield ScrollableContainer(IPCStructureTab(self.reader))
+        with TabPane("Schema", id="tab-schema"):
+            yield ScrollableContainer(IPCSchemaTab(self.reader))
+        with TabPane("Data", id="tab-data"):
+            yield ScrollableContainer(IPCDataTab(self.reader))
+        with TabPane("Metadata", id="tab-metadata"):
+            yield ScrollableContainer(IPCMetadataTab(self.reader))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pyarrow as pa
+import pyarrow.ipc as ipc
 import pyarrow.parquet as pq
 import pytest
 
@@ -135,4 +136,89 @@ def invalid_parquet_file(tmp_path: Path) -> Path:
     """
     file_path = tmp_path / "not_a_parquet.dat"
     file_path.write_text("This is not a Parquet file")
+    return file_path
+
+
+# --- Arrow IPC fixtures ---
+
+
+@pytest.fixture
+def simple_ipc(tmp_path: Path) -> Path:
+    """Create a simple test Arrow IPC file with basic types.
+
+    Returns:
+        Path to the created Arrow IPC file
+    """
+    table = pa.table(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": ["Alice", "Bob", "Charlie", "David", "Eve"],
+            "age": [25, 30, 35, 40, 45],
+            "score": [85.5, 90.0, 78.5, 92.0, 88.5],
+        }
+    )
+    file_path = tmp_path / "simple.arrow"
+    with ipc.new_file(file_path, table.schema) as writer:
+        writer.write_table(table)
+    return file_path
+
+
+@pytest.fixture
+def multi_batch_ipc(tmp_path: Path) -> Path:
+    """Create an Arrow IPC file with multiple record batches.
+
+    Returns:
+        Path to the created Arrow IPC file
+    """
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("value", pa.int64()),
+            ("category", pa.string()),
+        ]
+    )
+    file_path = tmp_path / "multi_batch.arrow"
+    with ipc.new_file(file_path, schema) as writer:
+        for batch_idx in range(3):
+            offset = batch_idx * 100
+            batch = pa.record_batch(
+                {
+                    "id": list(range(offset, offset + 100)),
+                    "value": [i * 2 for i in range(offset, offset + 100)],
+                    "category": [f"cat_{i % 10}" for i in range(100)],
+                },
+                schema=schema,
+            )
+            writer.write_batch(batch)
+    return file_path
+
+
+@pytest.fixture
+def empty_ipc(tmp_path: Path) -> Path:
+    """Create an empty Arrow IPC file (schema but no rows).
+
+    Returns:
+        Path to the created Arrow IPC file
+    """
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("name", pa.string()),
+        ]
+    )
+    file_path = tmp_path / "empty.arrow"
+    with ipc.new_file(file_path, schema):
+        pass
+    return file_path
+
+
+@pytest.fixture
+def invalid_ipc_file(tmp_path: Path) -> Path:
+    """Create a file with invalid Arrow IPC content.
+
+    Returns:
+        Path to the created invalid file
+    """
+    file_path = tmp_path / "not_an_arrow.arrow"
+    file_path.write_text("This is not an Arrow IPC file")
     return file_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,11 +36,11 @@ def test_cli_launches_app_with_valid_file(mock_app: Mock, simple_parquet: Path) 
 
 
 @patch("datanomy.cli.DatanomyApp")
-@patch("datanomy.cli.ParquetReader")
+@patch("datanomy.cli.create_reader")
 def test_cli_creates_reader(
     mock_reader: Mock, mock_app: Mock, simple_parquet: Path
 ) -> None:
-    """Test that CLI creates a ParquetReader with the correct file path."""
+    """Test that CLI creates a reader with the correct file path."""
     runner = CliRunner()
     runner.invoke(main, [str(simple_parquet)])
 
@@ -58,3 +58,17 @@ def test_cli_accepts_parquet_without_extension(
 
         # Should accept file based on content, not extension
         assert result.exit_code == 0
+
+
+@patch("datanomy.cli.DatanomyApp")
+def test_cli_launches_app_with_ipc_file(mock_app: Mock, simple_ipc: Path) -> None:
+    """Test that CLI launches the app with a valid Arrow IPC file."""
+    mock_app_instance = Mock()
+    mock_app.return_value = mock_app_instance
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(simple_ipc)])
+
+    assert mock_app.called
+    assert mock_app_instance.run.called
+    assert result.exit_code == 0

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,10 +1,11 @@
-"""Tests for the ParquetReader module."""
+"""Tests for the reader modules."""
 
 from pathlib import Path
 
 import pytest
 from pyarrow.lib import ArrowInvalid
 
+from datanomy.reader.ipc import IPCReader
 from datanomy.reader.parquet import ParquetReader
 
 
@@ -98,3 +99,64 @@ def test_row_group_total_sizes(simple_parquet: Path) -> None:
     compressed_size, uncompressed_size = row_group.total_sizes
     assert compressed_size == 474
     assert uncompressed_size == 487
+
+
+# --- IPCReader tests ---
+
+
+def test_ipc_reader_simple_file(simple_ipc: Path) -> None:
+    """Test reader with a simple Arrow IPC file."""
+    reader = IPCReader(simple_ipc)
+
+    assert reader.file_path == simple_ipc
+    assert reader.num_rows == 5
+    assert reader.num_record_batches == 1
+    assert len(reader.schema_arrow) == 4
+    assert reader.file_size > 0
+
+
+def test_ipc_reader_multi_batches(multi_batch_ipc: Path) -> None:
+    """Test reader with multiple record batches."""
+    reader = IPCReader(multi_batch_ipc)
+
+    assert reader.num_rows == 300
+    assert reader.num_record_batches == 3
+
+    for i in range(reader.num_record_batches):
+        batch = reader.get_batch(i)
+        assert batch.num_rows == 100
+
+
+def test_ipc_reader_empty_file(empty_ipc: Path) -> None:
+    """Test reader with empty Arrow IPC file."""
+    reader = IPCReader(empty_ipc)
+
+    assert reader.num_rows == 0
+    assert reader.num_record_batches == 0
+    assert len(reader.schema_arrow) == 2
+    assert reader.file_size > 0
+
+
+def test_ipc_reader_nonexistent_file(tmp_path: Path) -> None:
+    """Test that IPCReader raises FileNotFoundError for nonexistent files."""
+    nonexistent = tmp_path / "nonexistent.arrow"
+
+    with pytest.raises(FileNotFoundError, match="File not found"):
+        IPCReader(nonexistent)
+
+
+def test_ipc_reader_invalid_file(invalid_ipc_file: Path) -> None:
+    """Test that IPCReader raises ArrowInvalid for non-IPC files."""
+    with pytest.raises(
+        ArrowInvalid, match="does not appear to be a valid Arrow IPC file"
+    ):
+        IPCReader(invalid_ipc_file)
+
+
+def test_ipc_reader_metadata(simple_ipc: Path) -> None:
+    """Test that IPCReader can access schema metadata."""
+    reader = IPCReader(simple_ipc)
+
+    # Simple files without custom metadata should return None
+    metadata = reader.metadata
+    assert metadata is None or isinstance(metadata, dict)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from datanomy.reader.ipc import IPCReader
 from datanomy.reader.parquet import ParquetReader
 from datanomy.tui.tui import DatanomyApp
 
@@ -98,4 +99,62 @@ async def test_app_with_multiple_row_groups(multi_row_group_parquet: Path) -> No
 
     async with app.run_test():
         # Should handle multiple row groups without crashing
+        app.query_one("#structure-content").render()
+
+
+# --- Arrow IPC TUI tests ---
+
+
+@pytest.mark.asyncio
+async def test_ipc_app_launches_without_crash(simple_ipc: Path) -> None:
+    """Test that app launches with an IPC file without crashing."""
+    reader = IPCReader(simple_ipc)
+    app = DatanomyApp(reader)
+
+    async with app.run_test():
+        assert app is not None
+
+
+@pytest.mark.asyncio
+async def test_ipc_app_has_required_tabs(simple_ipc: Path) -> None:
+    """Test that all expected IPC tabs are present (no Stats tab)."""
+    reader = IPCReader(simple_ipc)
+    app = DatanomyApp(reader)
+
+    async with app.run_test():
+        assert app.query_one("#tab-structure") is not None
+        assert app.query_one("#tab-schema") is not None
+        assert app.query_one("#tab-data") is not None
+        assert app.query_one("#tab-metadata") is not None
+
+
+@pytest.mark.asyncio
+async def test_ipc_tabs_render_without_error(simple_ipc: Path) -> None:
+    """Test that IPC tab content renders without throwing exceptions."""
+    reader = IPCReader(simple_ipc)
+    app = DatanomyApp(reader)
+
+    async with app.run_test():
+        app.query_one("#structure-content").render()
+        app.query_one("#schema-content").render()
+
+
+@pytest.mark.asyncio
+async def test_ipc_app_with_empty_file(empty_ipc: Path) -> None:
+    """Test that app handles empty Arrow IPC files."""
+    reader = IPCReader(empty_ipc)
+    app = DatanomyApp(reader)
+
+    async with app.run_test():
+        app.query_one("#structure-content").render()
+        app.query_one("#schema-content").render()
+
+
+@pytest.mark.asyncio
+async def test_ipc_app_with_multiple_batches(multi_batch_ipc: Path) -> None:
+    """Test that app handles multiple record batches."""
+    reader = IPCReader(multi_batch_ipc)
+    app = DatanomyApp(reader)
+
+    async with app.run_test():
         app.query_one("#structure-content").render()


### PR DESCRIPTION
This PR adds IPC reader support so we can call `datanomy` on an Arrow File also.

<img width="1318" height="437" alt="Screenshot 2026-04-24 at 12 27 40" src="https://github.com/user-attachments/assets/272916ac-ad92-4153-beb1-0e7db2fc6023" />
<br>
<img width="1318" height="498" alt="Screenshot 2026-04-24 at 12 27 46" src="https://github.com/user-attachments/assets/221acbe1-eb4f-40a7-8728-9b687816bfdb" />
<br>
<img width="1318" height="310" alt="Screenshot 2026-04-24 at 12 27 54" src="https://github.com/user-attachments/assets/9a7605b4-8121-4637-8fab-0d40fbe50780" />
<br>
<img width="1318" height="348" alt="Screenshot 2026-04-24 at 12 28 01" src="https://github.com/user-attachments/assets/a81c3a9a-6651-40f4-81fb-dd22b218c290" />
<br>

The PR has been done mainly by Claude but I have gone through the implementation step by step, reviewed, tested and have run linter myself.

Closes: https://github.com/raulcd/datanomy/issues/4